### PR TITLE
Adjust for change in state change publishing in homegear

### DIFF
--- a/homegear-mqtt.js
+++ b/homegear-mqtt.js
@@ -26,7 +26,7 @@ module.exports = function(RED) {
 		this.publishComplete = n.publishComplete;
 
 
-		this.eventTopic = 'homegear/' + this.homegearId + '/event/' + this.peerId + '/#';
+		this.eventTopic = 'homegear/' + this.homegearId + '/json/' + this.peerId + '/#';
 		this.rpcTopic   = 'homegear/' + this.homegearId + '/rpcResult';
 		this.rpcId      = Math.floor(1 + Math.random() * 7295);
 


### PR DESCRIPTION
Variable state changes are no longer published to "event", but are now published to:

homegear/HOMEGEAR_ID/plain/PEERID/CHANNEL/VARIABLE_NAME
homegear/HOMEGEAR_ID/json/PEERID/CHANNEL/VARIABLE_NAME
homegear/HOMEGEAR_ID/jsonobj/PEERID/CHANNEL/VARIABLE_NAME

Probably further changes in the homegear util are required.