### PR TITLE
Fix issue in boolean value dropdown

### DIFF
--- a/homegear-mqtt.html
+++ b/homegear-mqtt.html
@@ -262,7 +262,7 @@
 								break;
 
 							case 'boolean':
-								var selected = $('#node-input-paramValue').val();
+								var selected = Number($('#node-input-paramValue').val()) || 0;
 
 								$('<option></option>').val(0).text('false')
 													  .appendTo('#node-input-paramValueList');

--- a/homegear-mqtt.html
+++ b/homegear-mqtt.html
@@ -262,13 +262,14 @@
 								break;
 
 							case 'boolean':
-								var select = Number($('#node-input-paramValue').val()) || 0;
+								var selected = $('#node-input-paramValue').val();
 
 								$('<option></option>').val(0).text('false')
 													  .appendTo('#node-input-paramValueList');
 								$('<option></option>').val(1).text('true')
 													  .appendTo('#node-input-paramValueList');
 
+								$('#node-input-paramValueList').val(selected).change();
 								$('#node-input-paramValueList').show();
 								$('#node-input-paramValueRow').show();
 								break;


### PR DESCRIPTION
Fixing the issue that the boolean value dropdown did not show the set value on opening the node, leading to confusing behaviour when setting the value.