### PR TITLE
deleted channel 5 TEMPERATURE at HM-WDS30-OT2-SM

### DIFF
--- a/families/homematic.json
+++ b/families/homematic.json
@@ -9338,10 +9338,6 @@
         "channel": 4
       },
       {
-        "name": "WEATHER.TEMPERATURE",
-        "channel": 5
-      },
-      {
         "name": "WEATHER.LOWBAT",
         "channel": 5
       }


### PR DESCRIPTION
The HM-WDS30-OT2-SM has only WEATHER.LOWBAT on channel 5, so i deleted WEATHER.TERMPERATURE.